### PR TITLE
Add reply functionality and recipient search to mailbox

### DIFF
--- a/languages/en_lang.lua
+++ b/languages/en_lang.lua
@@ -6,7 +6,7 @@ Locales["en_lang"] = {
     ReceivedMessages = 'Received Messages',
     MessageContent = 'Message Content',
     SelectRecipient = 'Select a Recipient',
-    SendPigeon = 'Send Pigeon',
+    SendPigeon = 'Send Mail',
     InvalidRecipient = 'Invalid recipient, subject, or message',
     MailDeleted = 'Mail deleted successfully.',
     MailDeletionFailed = 'Failed to delete mail.',
@@ -44,4 +44,5 @@ Locales["en_lang"] = {
     NearMailbox = 'Near Mailbox',
     NewMailNotification = 'You have received new mail.',
     mailFrom = 'From:',
+    ReplyButtonLabel = 'Reply',
 }

--- a/languages/ro_lang.lua
+++ b/languages/ro_lang.lua
@@ -44,4 +44,5 @@ Locales["ro_lang"] = {
     NearMailbox = 'Cutie Postala',
     NewMailNotification = 'Ai o telegrama necitita.',
     mailFrom = 'De la:',
+    ReplyButtonLabel = 'Raspunde',
 }


### PR DESCRIPTION
- Introduces a Reply button to the message view, allowing users to reply directly to messages with pre-filled subject and recipient.
- Adds a search input to the recipient selection page for easier navigation.
- Updates the English locale with a label for the reply button.
- Stop showing current users own mailbox in the list.