### PR TITLE
Cleanup: Use DevPrint Instead of NotifyClient for Mailbox Failures

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -38,4 +38,4 @@ dependency {
 	'bcc-utils'
 }
 
-version '1.1.0'
+version '1.1.1'

--- a/server/server.lua
+++ b/server/server.lua
@@ -225,8 +225,7 @@ BccUtils.RPC:Register('bcc-mailbox:UpdateMailboxInfo', function(params, cb, src)
         return
     end
 
-    DevPrint('UpdateMailboxInfo: update failed for char_identifier=', charIdentifier)
-    NotifyClient(src, _U('UpdateMailboxFailed') .. tostring(charIdentifier), 'error', 4000)
+    DevPrint('UpdateMailboxInfo: failed to update mailbox for char_identifier=' .. tostring(charIdentifier))
     cb(false)
 end)
 

--- a/version
+++ b/version
@@ -1,3 +1,5 @@
+<1.1.1>
+- Replaced client error notification with internal debug logging for mailbox update failures.
 <1.1.0>
 - Fixed typo
 - Add blip creation for mailbox locations and cleanup on resource stop
@@ -16,3 +18,4 @@
 - Fixed multiple **menu-related issues**.
 - Removed unnecessary **string formatting in menus**.
 - Various other **stability and performance improvements**.
+<1.0.0>


### PR DESCRIPTION
- Replaced client error notification with internal debug logging for mailbox update failures.